### PR TITLE
#29 - ParserSelectorFactory_관련_버그_수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,7 @@ gradle-app.setting
 *.hprof
 
 # 사용자 정의
+.env
+set_env_var.sh
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,intellij+all,gradle,java

--- a/src/main/java/com/iksad/simpluencer/exception/ErrorType/DataIntegrityViolationType.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ErrorType/DataIntegrityViolationType.java
@@ -25,7 +25,7 @@ public class DataIntegrityViolationType extends SimpluencerException {
 
     @Override
     public String getMessageForClient() {
-        return String.format("'%s'가 %s 값으로 입력됐습니다.",  this.result.column(), this.getInput());
+        return String.format(this.getComment(),  this.result.column(), this.getInput());
     }
 
     @Override
@@ -36,6 +36,14 @@ public class DataIntegrityViolationType extends SimpluencerException {
     protected String getInput() {
         return Optional.ofNullable(this.result.input())
                 .map(s -> String.format("'%s'", s))
-                .orElse("빈");
+                .orElse("");
+    }
+
+    protected String getComment() {
+        if(this.result.input() == null) {
+            return "'%s'에 입력된 값이 없습니다.%s";
+        } else {
+            return "'%s'에 입력된 값인 '%s'이 이미 존재합니다.";
+        }
     }
 }

--- a/src/main/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ExceptionParserFactory.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ExceptionParserFactory.java
@@ -1,10 +1,11 @@
 package com.iksad.simpluencer.exception.ExceptionParserFactory;
 
 import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.DataIntegrityViolationExceptionParser;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
 public interface ExceptionParserFactory {
 
-    Optional<DataIntegrityViolationExceptionParser> newInstance(Exception e);
+    Optional<DataIntegrityViolationExceptionParser> newInstance(DataIntegrityViolationException e);
 }

--- a/src/main/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ParserSelectorFactory.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ParserSelectorFactory.java
@@ -3,6 +3,7 @@ package com.iksad.simpluencer.exception.ExceptionParserFactory;
 import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.DataIntegrityViolationExceptionParser;
 import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.NotNullViolationParser;
 import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.UniqueViolationParser;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -15,12 +16,12 @@ public class ParserSelectorFactory implements ExceptionParserFactory {
         UniqueViolationParser.class
     );
 
-    public Optional<DataIntegrityViolationExceptionParser> newInstance(Exception e) {
+    public Optional<DataIntegrityViolationExceptionParser> newInstance(DataIntegrityViolationException e) {
         for(Class<? extends DataIntegrityViolationExceptionParser> parserClass : parserClasses) {
             DataIntegrityViolationExceptionParser parser;
             try {
                 parser = parserClass
-                        .getConstructor(Exception.class)
+                        .getConstructor(DataIntegrityViolationException.class)
                         .newInstance(e);
             } catch (ReflectiveOperationException ex) {
                 continue;

--- a/src/test/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ParserSelectorFactoryTest.java
+++ b/src/test/java/com/iksad/simpluencer/exception/ExceptionParserFactory/ParserSelectorFactoryTest.java
@@ -1,0 +1,43 @@
+package com.iksad.simpluencer.exception.ExceptionParserFactory;
+
+import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.DataIntegrityViolationExceptionParser;
+import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.NotNullViolationParser;
+import com.iksad.simpluencer.exception.DataIntegrityViolationExceptionParser.UniqueViolationParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParserSelectorFactoryTest {
+    private ParserSelectorFactory parserSelectorFactory;
+
+    private static final DataIntegrityViolationException nonUniqueException = new DataIntegrityViolationException("""
+                could not execute statement [Unique index or primary key violation: "PUBLIC.CONSTRAINT_INDEX_3 ON PUBLIC.AGENT(EMAIL NULLS FIRST) VALUES ( /* 2 */ 'mock email' )"; SQL statement:
+                insert into agent (created_at,email,nickname,password,id) values (?,?,?,?,default) [23505-214]] [insert into agent (created_at,email,nickname,password,id) values (?,?,?,?,default)]; SQL [insert into agent (created_at,email,nickname,password,id) values (?,?,?,?,default)]; constraint ["PUBLIC.CONSTRAINT_INDEX_3 ON PUBLIC.AGENT(EMAIL NULLS FIRST) VALUES ( /* 2 */ 'mock email' )"; SQL statement:
+                insert into agent (created_at,email,nickname,password,id) values (?,?,?,?,default) [23505-214]]
+                """.trim());
+    private static final DataIntegrityViolationException nullException = new DataIntegrityViolationException("""
+                not-null property references a null or transient value : com.iksad.simpluencer.entity.Agent.email
+                """.trim());
+
+    @Test @DisplayName("[newInstance][정상]")
+    void newInstance() {
+        // Given
+        parserSelectorFactory = new ParserSelectorFactory();
+
+        // When
+        Optional<DataIntegrityViolationExceptionParser> nonUniqueExceptionParser = parserSelectorFactory.newInstance(nonUniqueException);
+        Optional<DataIntegrityViolationExceptionParser> nullExceptionParser = parserSelectorFactory.newInstance(nullException);
+
+        // then
+        assertThat(nonUniqueExceptionParser.isPresent()).isTrue();
+        assertThat(nullExceptionParser.isPresent()).isTrue();
+
+        assert nonUniqueExceptionParser.get() instanceof UniqueViolationParser;
+        assert nullExceptionParser.get() instanceof NotNullViolationParser;
+
+    }
+}


### PR DESCRIPTION
# 개요
ParserSelectorFactory 기능이 제대로 작동되지 않았다.
어떤 이유에서든 DataIntegrityViolationExceptionParser 구현체들을 인식하지 못하고 모두 AbnormalDataIntegrityViolationType를 출력했다. 이를 고침.