### PR TITLE
#33 - Google_OAuth2_AccessToken_및_Refresh_Token_취득_및_저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.projectlombok:lombok:1.18.26'
     testImplementation 'org.springframework.security:spring-security-test'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'

--- a/src/main/java/com/iksad/simpluencer/config/AuthenticationConfig.java
+++ b/src/main/java/com/iksad/simpluencer/config/AuthenticationConfig.java
@@ -1,10 +1,13 @@
 package com.iksad.simpluencer.config;
 
+import com.iksad.simpluencer.service.OAuth2PanelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
@@ -15,6 +18,9 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 @RequiredArgsConstructor
 public class AuthenticationConfig {
     private final AuthenticationFailureHandler authenticationFailureHandler;
+    private final OAuth2PanelService oAuth2PanelService;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -61,6 +67,20 @@ public class AuthenticationConfig {
                 .csrf(
                         b -> b
                                 .ignoringRequestMatchers(antMatcher("/h2/**"))
+                )
+
+                .oauth2Login(
+                        b -> b
+                                .defaultSuccessUrl("/auth/login")
+                                .failureUrl("/auth/login/oauth/fail")
+
+                                .clientRegistrationRepository(clientRegistrationRepository)
+                                .authorizedClientService(oAuth2AuthorizedClientService)
+
+                                .userInfoEndpoint(
+                                        e -> e
+                                                .userService(oAuth2PanelService)
+                                )
                 )
 
                 .build();

--- a/src/main/java/com/iksad/simpluencer/config/OAuthConfig.java
+++ b/src/main/java/com/iksad/simpluencer/config/OAuthConfig.java
@@ -1,0 +1,53 @@
+package com.iksad.simpluencer.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+public class OAuthConfig {
+    private final Map<String, OAuth2ClientProperties.Registration> registrations;
+    private final Map<String, OAuth2ClientProperties.Provider> providers;
+
+    @Autowired
+    public OAuthConfig(OAuth2ClientProperties oAuth2ClientProperties) {
+        this.registrations = oAuth2ClientProperties.getRegistration();
+        this.providers = oAuth2ClientProperties.getProvider();
+    }
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        List<ClientRegistration> clientRegistrations = registrations.keySet().stream()
+                .map(this::castToClientRegistration)
+                .toList();
+        return new InMemoryClientRegistrationRepository(clientRegistrations);
+    }
+
+    private ClientRegistration castToClientRegistration(String registrationId) {
+        OAuth2ClientProperties.Registration registration = registrations.get(registrationId);
+        OAuth2ClientProperties.Provider provider = providers.get(registrationId);
+
+        return ClientRegistration.withRegistrationId(registrationId)
+
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .clientId(registration.getClientId())
+                .clientSecret(registration.getClientSecret())
+                .redirectUri(registration.getRedirectUri())
+                .scope(registration.getScope())
+
+                .authorizationUri(provider.getAuthorizationUri())
+                .tokenUri(provider.getTokenUri())
+                .userNameAttributeName(provider.getUserNameAttribute())
+
+                .build();
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/entity/Agent.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Agent.java
@@ -26,6 +26,9 @@ public class Agent extends BaseEntity {
     @OneToMany(mappedBy = "agent", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
     private Collection<RoleOfAgent> roles;
 
+    @OneToMany(mappedBy = "agent", cascade = {CascadeType.REMOVE})
+    private Collection<Panel> panels;
+
     public void setRoles(Collection<RoleOfAgent> roles) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/com/iksad/simpluencer/entity/Panel.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Panel.java
@@ -1,0 +1,25 @@
+package com.iksad.simpluencer.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "panel", indexes = {
+        @Index(columnList = "agent_id")
+})
+@NoArgsConstructor @Getter @Setter
+public class Panel extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_id", nullable = false)
+    private Agent agent;
+
+    private String provider;
+
+    private String principalName;
+
+    private String description;
+
+    private int location;
+}

--- a/src/main/java/com/iksad/simpluencer/entity/Scope.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Scope.java
@@ -1,0 +1,19 @@
+package com.iksad.simpluencer.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "access_token_scope", indexes = {
+        @Index(columnList = "token_id")
+})
+@NoArgsConstructor @Getter @Setter
+public class Scope extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "token_id")
+    private Token token;
+
+    private String scope;
+}

--- a/src/main/java/com/iksad/simpluencer/entity/Token.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Token.java
@@ -1,0 +1,87 @@
+package com.iksad.simpluencer.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Entity
+@Table(name = "token", indexes = {
+        @Index(columnList = "provider"),
+        @Index(columnList = "principalName")
+})
+@NoArgsConstructor @Getter @Setter
+public class Token extends BaseEntity {
+    private String provider;
+
+    private String principalName;
+
+    @Column(unique = true)
+    private String refreshToken;
+
+    private Instant issuedAtRefreshToken;
+
+    private Instant expiresAtRefreshToken;
+
+    @Column(unique = true)
+    private String accessToken;
+
+    private Instant issuedAtAccessToken;
+
+    private Instant expiresAtAccessToken;
+
+    @OneToMany(mappedBy = "token", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private Set<Scope> scopes;
+
+    public static Token fromOAuth2AuthorizedClient(OAuth2AuthorizedClient authorizedClient) {
+        Token entity = new Token();
+        entity.setProvider(authorizedClient.getClientRegistration().getClientId());
+        entity.setPrincipalName(authorizedClient.getPrincipalName());
+
+        entity.setAccessToken(authorizedClient.getAccessToken().getTokenValue());
+        entity.setIssuedAtAccessToken(authorizedClient.getAccessToken().getIssuedAt());
+        entity.setExpiresAtAccessToken(authorizedClient.getAccessToken().getExpiresAt());
+
+        entity.setRefreshToken(authorizedClient.getRefreshToken().getTokenValue());
+        entity.setIssuedAtRefreshToken(authorizedClient.getRefreshToken().getIssuedAt());
+        entity.setExpiresAtRefreshToken(authorizedClient.getRefreshToken().getExpiresAt());
+
+        Set<Scope> scopeTable = new HashSet<>();
+        for(String scope : authorizedClient.getAccessToken().getScopes()) {
+            Scope scopeEntity = new Scope();
+            scopeEntity.setToken(entity);
+            scopeEntity.setScope(scope);
+            scopeTable.add(scopeEntity);
+        }
+        entity.setScopes(scopeTable);
+        return entity;
+    }
+
+    public OAuth2AccessToken getOAuth2AccessToken() {
+        return new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                this.getAccessToken(),
+                this.getIssuedAtAccessToken(),
+                this.getExpiresAtAccessToken(),
+                this.getScopes().stream()
+                        .map(Scope::getScope)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
+    }
+
+    public OAuth2RefreshToken getOAuth2RefreshToken() {
+        return new OAuth2RefreshToken(
+                this.getRefreshToken(),
+                this.getIssuedAtRefreshToken(),
+                this.getExpiresAtRefreshToken()
+        );
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/exception/ErrorType/AuthTokenNotFoundType.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ErrorType/AuthTokenNotFoundType.java
@@ -1,0 +1,28 @@
+package com.iksad.simpluencer.exception.ErrorType;
+
+import com.iksad.simpluencer.exception.SimpluencerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class AuthTokenNotFoundType extends SimpluencerException {
+    private final String clientRegistrationId;
+    private final String principalName;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public String getMessageForClient() {
+        return "해당 플랫폼의 계정으로는 등록되지 않습니다.";
+    }
+
+    public String getMessageForServer() {
+        return String.format(
+                "존재하지 않는 인증 토큰을 요구함.\nPlatform|%s\nId_in_this_platform|%s"
+                , this.clientRegistrationId, this.principalName
+        );
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/exception/ErrorType/ForbiddenUser.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ErrorType/ForbiddenUser.java
@@ -1,0 +1,21 @@
+package com.iksad.simpluencer.exception.ErrorType;
+
+import com.iksad.simpluencer.exception.SimpluencerException;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenUser extends SimpluencerException {
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+
+    @Override
+    public String getMessageForClient() {
+        return "접근 권한이 없습니다.";
+    }
+
+    @Override
+    public String getMessageForServer() {
+        return "인가 오류 발생";
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/model/AgentDto.java
+++ b/src/main/java/com/iksad/simpluencer/model/AgentDto.java
@@ -20,7 +20,8 @@ public record AgentDto(
         String email,
         String password,
         String nickname,
-        Collection<RoleType> roles
+        Collection<RoleType> roles,
+        Collection<PanelDto> panelDtos
 ) implements UserDetails {
     public static AgentDto fromEntity(Agent entity) {
         return AgentDto.builder()
@@ -33,6 +34,16 @@ public record AgentDto(
 
                 .roles(TypeTransformUtils.map(entity.getRoles(), RoleOfAgent::getRole))
                 .build();
+    }
+
+    public Agent toEntity() {
+        Agent entity = new Agent();
+        entity.setId(this.id);
+        entity.setCreatedAt(this.createdAt);
+        entity.setEmail(this.email);
+        entity.setPassword(this.password);
+        entity.setNickname(this.nickname);
+        return entity;
     }
 
     @Override

--- a/src/main/java/com/iksad/simpluencer/model/PanelDto.java
+++ b/src/main/java/com/iksad/simpluencer/model/PanelDto.java
@@ -1,0 +1,48 @@
+package com.iksad.simpluencer.model;
+
+import com.iksad.simpluencer.entity.Panel;
+import lombok.Builder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Builder(toBuilder = true)
+public record PanelDto(
+        AgentDto agentDto,
+        String provider,
+        String principalName,
+        String description,
+        int location,
+        Map<String, Object> attributes
+    ) implements OAuth2User {
+
+    public static PanelDto fromEntity(Panel entity) {
+        return PanelDto.builder()
+                .provider(entity.getProvider())
+                .principalName(entity.getPrincipalName())
+                .description(entity.getDescription())
+                .location(entity.getLocation())
+                .build();
+    }
+
+    @Override
+    public String getName() { return this.principalName; }
+    @Override
+    public Map<String, Object> getAttributes() { return this.attributes; }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { return this.agentDto.getAuthorities(); }
+
+    public Panel toEntity() {
+        assert this.agentDto != null;
+
+        Panel entity = new Panel();
+        entity.setAgent(this.agentDto.toEntity());
+        entity.setProvider(this.provider);
+        entity.setPrincipalName(this.principalName);
+        entity.setDescription(this.description);
+        entity.setLocation(this.location);
+        return entity;
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/repository/PanelRepository.java
+++ b/src/main/java/com/iksad/simpluencer/repository/PanelRepository.java
@@ -1,0 +1,10 @@
+package com.iksad.simpluencer.repository;
+
+import com.iksad.simpluencer.entity.Panel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PanelRepository extends JpaRepository<Panel, Long> {
+    Optional<Panel> findByProviderAndPrincipalName(String clientRegistrationId, String principalName);
+}

--- a/src/main/java/com/iksad/simpluencer/repository/TokenRepository.java
+++ b/src/main/java/com/iksad/simpluencer/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package com.iksad.simpluencer.repository;
+
+import com.iksad.simpluencer.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByProviderAndPrincipalName(String clientRegistrationId, String principalName);
+
+    void deleteByProviderAndPrincipalName(String clientRegistrationId, String principalName);
+}

--- a/src/main/java/com/iksad/simpluencer/service/OAuth2AgentServiceImpl.java
+++ b/src/main/java/com/iksad/simpluencer/service/OAuth2AgentServiceImpl.java
@@ -1,0 +1,38 @@
+package com.iksad.simpluencer.service;
+
+import com.iksad.simpluencer.entity.Panel;
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.PanelDto;
+import com.iksad.simpluencer.repository.PanelRepository;
+import com.iksad.simpluencer.service.PanelDtoFactory.OAuth2PanelDtoFactory;
+import com.iksad.simpluencer.type.PlatformType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OAuth2AgentServiceImpl implements OAuth2PanelService {
+    private final PanelRepository panelRepository;
+
+    @Override
+    public PanelDto loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        PlatformType platformType = PlatformType.providerOf(provider);
+        OAuth2PanelDtoFactory OAuth2PanelDtoFactory = platformType.getOAuth2PanelDtoFactory();
+
+        PanelDto panelDtoFromOAuth2 = OAuth2PanelDtoFactory.newInstance(userRequest);
+
+        Panel panel = panelRepository.findByProviderAndPrincipalName(
+                panelDtoFromOAuth2.provider(), panelDtoFromOAuth2.principalName()
+        ).orElseGet(() -> panelRepository.save(panelDtoFromOAuth2.toEntity()));
+
+        return PanelDto.fromEntity(panel)
+                .toBuilder()
+                .agentDto(AgentDto.fromEntity(panel.getAgent()))
+                .build();
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/service/OAuth2AuthorizedClientServiceImpl.java
+++ b/src/main/java/com/iksad/simpluencer/service/OAuth2AuthorizedClientServiceImpl.java
@@ -1,0 +1,47 @@
+package com.iksad.simpluencer.service;
+
+import com.iksad.simpluencer.entity.Token;
+import com.iksad.simpluencer.exception.ErrorType.AuthTokenNotFoundType;
+import com.iksad.simpluencer.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OAuth2AuthorizedClientServiceImpl implements OAuth2AuthorizedClientService {
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public OAuth2AuthorizedClient loadAuthorizedClient(String clientRegistrationId, String principalName) {
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(clientRegistrationId);
+
+        Token token = tokenRepository.findByProviderAndPrincipalName(clientRegistrationId, principalName)
+                .orElseThrow(() -> new AuthTokenNotFoundType(clientRegistrationId, principalName));
+
+        return new OAuth2AuthorizedClient(
+                clientRegistration,
+                principalName,
+                token.getOAuth2AccessToken(),
+                token.getOAuth2RefreshToken()
+        );
+    }
+
+    @Override
+    public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
+        tokenRepository.save(Token.fromOAuth2AuthorizedClient(authorizedClient));
+    }
+
+    @Override
+    public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
+        tokenRepository.deleteByProviderAndPrincipalName(clientRegistrationId, principalName);
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/service/OAuth2PanelService.java
+++ b/src/main/java/com/iksad/simpluencer/service/OAuth2PanelService.java
@@ -1,0 +1,8 @@
+package com.iksad.simpluencer.service;
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public interface OAuth2PanelService extends OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+}

--- a/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/FaceBookPanelDtoFactory.java
+++ b/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/FaceBookPanelDtoFactory.java
@@ -1,0 +1,31 @@
+package com.iksad.simpluencer.service.PanelDtoFactory;
+
+import com.iksad.simpluencer.exception.ErrorType.ForbiddenUser;
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.PanelDto;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+
+import java.util.Map;
+
+public class FaceBookPanelDtoFactory extends OAuth2PanelDtoFactory {
+    @Override
+    public PanelDto newInstance(OAuth2UserRequest request) {
+        AgentDto agentDto = this.getPrincipal()
+                .orElseThrow(() -> new ForbiddenUser());
+
+        return PanelDto.builder()
+                .agentDto(agentDto)
+
+                .provider(this.getProvider(request))
+                .principalName(this.getPrincipalName(request))
+
+                .attributes(this.getAttributes(request))
+                .build();
+    }
+
+    @Override
+    public String getPrincipalName(OAuth2UserRequest request) {
+        Map<String, Object> parameters = request.getAdditionalParameters();
+        return (String) parameters.getOrDefault("id", null);
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/GooglePanelDtoFactory.java
+++ b/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/GooglePanelDtoFactory.java
@@ -1,0 +1,65 @@
+package com.iksad.simpluencer.service.PanelDtoFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iksad.simpluencer.exception.ErrorType.ForbiddenUser;
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.PanelDto;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GooglePanelDtoFactory extends OAuth2PanelDtoFactory {
+    private static final Base64.Decoder decoder = Base64.getDecoder();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> typeRef = new TypeReference<>() {};
+
+    @Override
+    public PanelDto newInstance(OAuth2UserRequest request) {
+        Map<String, Object> parameters = request.getAdditionalParameters();
+        parameters = decode(parameters);
+
+        AgentDto agentDto = this.getPrincipal()
+                .orElseThrow(() -> new ForbiddenUser());
+
+        return PanelDto.builder()
+                .agentDto(agentDto)
+
+                .provider(this.getProvider(request))
+                .principalName(this.getPrincipalName(parameters))
+
+                .attributes(parameters)
+                .build();
+    }
+
+    private String getPrincipalName(Map<String, Object> parameters) {
+        return (String) parameters.getOrDefault("sub", null);
+    }
+
+    @Override
+    public String getPrincipalName(OAuth2UserRequest request) {
+        Map<String, Object> parameters = request.getAdditionalParameters();
+        return (String) parameters.getOrDefault("sub", null);
+    }
+
+    public static Map<String, Object> decode(Map<String, Object> attrs) {
+        Map<String, Object> result = new HashMap<>(attrs);
+        String idToken;
+
+        try {
+            idToken = (String) result.get("id_token");
+        } catch (NullPointerException e) { return attrs;}
+
+        String[] idTokenSplit = idToken.split("\\.");
+        byte[] payload = decoder.decode(idTokenSplit[1]);
+
+        try {
+            Map<String, Object> idTokenDecoded = objectMapper.readValue(payload, typeRef);
+            result.putAll(idTokenDecoded);
+        } catch (IOException ignored) {}
+        return result;
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/OAuth2PanelDtoFactory.java
+++ b/src/main/java/com/iksad/simpluencer/service/PanelDtoFactory/OAuth2PanelDtoFactory.java
@@ -1,0 +1,29 @@
+package com.iksad.simpluencer.service.PanelDtoFactory;
+
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.PanelDto;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class OAuth2PanelDtoFactory {
+    public static Optional<AgentDto> getPrincipal() {
+        return Optional.of(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .map(Authentication::getPrincipal)
+                .map(AgentDto.class::cast);
+    }
+    public static String getProvider(OAuth2UserRequest request) {
+        return request.getClientRegistration().getRegistrationId();
+    }
+    public static Map<String, Object> getAttributes(OAuth2UserRequest request) {
+        return request.getAdditionalParameters();
+    }
+
+    public abstract PanelDto newInstance(OAuth2UserRequest request);
+    public abstract String getPrincipalName(OAuth2UserRequest request);
+}

--- a/src/main/java/com/iksad/simpluencer/type/PlatformType.java
+++ b/src/main/java/com/iksad/simpluencer/type/PlatformType.java
@@ -1,0 +1,25 @@
+package com.iksad.simpluencer.type;
+
+import com.iksad.simpluencer.service.PanelDtoFactory.FaceBookPanelDtoFactory;
+import com.iksad.simpluencer.service.PanelDtoFactory.GooglePanelDtoFactory;
+import com.iksad.simpluencer.service.PanelDtoFactory.OAuth2PanelDtoFactory;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor @Getter
+public enum PlatformType {
+    GOOGLE("google", new GooglePanelDtoFactory()),
+    FACEBOOK("facebook", new FaceBookPanelDtoFactory());
+
+    private final String provider;
+    private final OAuth2PanelDtoFactory OAuth2PanelDtoFactory;
+
+    public static PlatformType providerOf(String arg) {
+        return Stream.of(PlatformType.values())
+                .filter(s -> s.getProvider().equals(arg))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/utils/OAuthRequestUriUtils.java
+++ b/src/main/java/com/iksad/simpluencer/utils/OAuthRequestUriUtils.java
@@ -1,0 +1,65 @@
+package com.iksad.simpluencer.utils;
+
+import org.springframework.data.util.Pair;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class OAuthRequestUriUtils {
+    private final static MultiValueMap<String, String> defaultQueries = new LinkedMultiValueMap<>();
+    private final static List<Pair<String, Function<ClientRegistration,String>>> additionQueryFunc = new LinkedList<>();
+
+    private final static String QUERY_DELIMITER = "&";
+    private final static String KEY_VALUE_DELIMITER = "=";
+    private final static String SCOPE_DELIMITER = " ";
+
+    static {
+        defaultQueries.add("response_type", "code");
+        defaultQueries.add("access_type", "offline");
+        defaultQueries.add("prompt", "consent");
+
+        additionQueryFunc.add(Pair.of("redirect_uri", ClientRegistration::getRedirectUri));
+        additionQueryFunc.add(Pair.of("client_id", ClientRegistration::getClientId));
+        additionQueryFunc.add(Pair.of("scope", clientRegistration -> String.join(SCOPE_DELIMITER, clientRegistration.getScopes())));
+    }
+
+    private static void parseQuery(String rawQueries, BiConsumer<String, String> mapperKeyAndValue) {
+        Optional.ofNullable(rawQueries)
+                .map(query -> query.split(QUERY_DELIMITER)).stream()
+                .flatMap(Stream::of)
+                .map(entry -> entry.split(KEY_VALUE_DELIMITER))
+                .forEach(keyAndValue -> {
+                    mapperKeyAndValue.accept(keyAndValue[0], keyAndValue[1]);
+                });
+    }
+
+    public static String getUri(ClientRegistration clientRegistration) {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(
+                        clientRegistration.getProviderDetails().getAuthorizationUri()
+                );
+
+        MultiValueMap<String, String> existedQueries = new LinkedMultiValueMap<>();
+        parseQuery(uriComponentsBuilder.build().getQuery(), existedQueries::add);
+
+        MultiValueMap<String, String> additionQueries = new LinkedMultiValueMap<>();
+        additionQueryFunc.stream()
+                .map(pair -> Pair.of(pair.getFirst(), pair.getSecond().apply(clientRegistration)))
+                .forEach(pair -> additionQueries.add(pair.getFirst(), pair.getSecond()));
+
+        MultiValueMap<String, String> queries = new LinkedMultiValueMap<>();
+        queries.addAll(defaultQueries);
+        queries.addAll(existedQueries);
+        queries.addAll(additionQueries);
+
+        return uriComponentsBuilder.replaceQueryParams(queries)
+                .build().toUriString();
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/utils/TypeTransformUtils.java
+++ b/src/main/java/com/iksad/simpluencer/utils/TypeTransformUtils.java
@@ -6,6 +6,8 @@ import java.util.function.Function;
 
 public class TypeTransformUtils {
     public static <T,U> Collection<U> map(Collection<T> before, Function<T,U> function) {
+        if(before == null) return null;
+
         HashSet<U> after = new HashSet<>();
         for(T role: before) {
             after.add(function.apply(role));

--- a/src/main/resources/application-oauth-local.yml
+++ b/src/main/resources/application-oauth-local.yml
@@ -1,0 +1,15 @@
+spring.security.oauth2.client:
+  registration:
+    google:
+      client-id: ${ OAUTH_CLIENT_ID }
+      client-secret: ${ OAUTH_SECRET }
+      scope:
+      - https://www.googleapis.com/auth/userinfo.email
+      - https://www.googleapis.com/auth/userinfo.profile
+      redirect-uri: http://localhost:8080/login/oauth2/code/google
+
+  provider:
+    google:
+      user-name-attribute: sub
+      authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+      token-uri: https://accounts.google.com/o/oauth2/token

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,5 +2,5 @@ spring:
   profiles:
     default: local
     group:
-      local: thymeleaf-local, datasource-local, h2db-local, email-local
+      local: thymeleaf-local, datasource-local, h2db-local, email-local, oauth-local
       prod: thymeleaf-prod

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -118,7 +118,7 @@ function request(url, options) {
       console.log(`<-- 응답 Header: \n`, response.headers);
       return response;
     })
-    .then(response =>{
+    .then(response => {
       //// 리다이렉션이면 수동으로 url를 교체함.
       if (response.redirected) {
         window.location.href = response.url;

--- a/src/test/java/com/iksad/simpluencer/utils/OAuthRequestUriUtilsTest.java
+++ b/src/test/java/com/iksad/simpluencer/utils/OAuthRequestUriUtilsTest.java
@@ -1,0 +1,69 @@
+package com.iksad.simpluencer.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@DisplayName("[OAuthRequestUriUtils]")
+class OAuthRequestUriUtilsTest {
+
+    @Test @DisplayName("[getUri][정상]")
+    void getUri() {
+        // Given
+        String clientId = "{clientId}";
+        String clientSecret = "{clientSecret}";
+
+        String provider = "google";
+        String redirect_uri = "http://localhost:8080/login/oauth2/code/google";
+        String[] scopes = new String[]{"email", "profile"};
+
+        String authorizationUri = "https://accounts.google.com/o/oauth2/v2/auth";
+        String tokenUri = "https://oauth2.googleapis.com/token";
+
+        ClientRegistration registration = ClientRegistration.withRegistrationId(provider)
+
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirect_uri)
+                .scope(scopes)
+
+                .authorizationUri(authorizationUri)
+                .tokenUri(tokenUri)
+
+                .build();
+
+        // When
+        String uri = OAuthRequestUriUtils.getUri(registration);
+        log.info(uri);
+
+        // then
+        assertThat(uri).contains(
+                "https://accounts.google.com/o/oauth2/v2/auth"
+        );
+        assertThat(uri).contains(
+                "client_id=" + clientId
+        );
+        assertThat(uri).contains(
+                "redirect_uri=" + redirect_uri
+        );
+        assertThat(uri).contains(
+                "scope="
+        );
+        for(String scope : scopes) {
+            assertThat(uri).contains(scope);
+        }
+        assertThat(uri).contains(
+                "response_type=code"
+        );
+        assertThat(uri).contains(
+                "access_type=offline"
+        );
+
+    }
+}


### PR DESCRIPTION
# 개요
1. 차후에 인증 토큰으로 사용할 Refresh Token과 Access Token 취득 Access Token,Refresh Token는 RDBMS에 저장.
2. Panel 엔티티 추가 설계. 해당 도메인은 각 유저가 가진 플랫폼을 의미함.
3. 플랫폼 링크를 누르면 해당 플랫폼의 액세스 토큰을 취득하게 됨과 동시에 등록됨.