### PR TITLE
#42 - panel_엔티티에_oauth_인증에_사용한_이메일_칼럼_추가

### DIFF
--- a/src/main/java/com/iksad/simpluencer/entity/Panel.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Panel.java
@@ -25,5 +25,7 @@ public class Panel extends BaseEntity {
 
     private String description;
 
+    private String email;
+
     private int location;
 }

--- a/src/main/java/com/iksad/simpluencer/model/response/PanelReadResponse.java
+++ b/src/main/java/com/iksad/simpluencer/model/response/PanelReadResponse.java
@@ -9,7 +9,8 @@ public record PanelReadResponse(
         Long id,
         String frontName,
         String icon,
-        String description
+        String description,
+        String email
 ) {
     public static PanelReadResponse of(Panel entity) {
         String provider = entity.getProvider();
@@ -19,6 +20,7 @@ public record PanelReadResponse(
                 .frontName(type.getFrontName())
                 .icon(type.getIcon())
                 .description(entity.getDescription())
+                .email(entity.getEmail())
                 .build();
     }
 }

--- a/src/main/java/com/iksad/simpluencer/service/OAuth2PanelServiceImpl.java
+++ b/src/main/java/com/iksad/simpluencer/service/OAuth2PanelServiceImpl.java
@@ -23,7 +23,7 @@ public class OAuth2PanelServiceImpl implements OAuth2PanelService {
     @Override
     public PanelDto loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
-        Panel entity = castRequestToEntity(userRequest, oAuth2User.getName());
+        Panel entity = castRequestToEntity(userRequest, oAuth2User);
         Panel saved = loadOrSave(entity);
 
         return PanelDto.fromEntity(saved)
@@ -39,10 +39,11 @@ public class OAuth2PanelServiceImpl implements OAuth2PanelService {
         ).orElseGet(() -> panelRepository.save(entity));
     }
 
-    public static Panel castRequestToEntity(OAuth2UserRequest request, String principalName) {
+    public static Panel castRequestToEntity(OAuth2UserRequest request, OAuth2User oAuth2User) {
         Panel entity = new Panel();
         entity.setProvider(getProvider(request));
-        entity.setPrincipalName(principalName);
+        entity.setPrincipalName(oAuth2User.getName());
+        entity.setEmail(oAuth2User.getAttribute("email"));
         return entity;
     }
 

--- a/src/main/resources/templates/component/platform.html
+++ b/src/main/resources/templates/component/platform.html
@@ -38,10 +38,21 @@
                     <h5 class="card-title" th:text="${panel.frontName}">
                         Platform
                     </h5>
-                    <p th:id="|card_platform_${panel.id}_label|" th:text="${panel.description}" class="card-text pos">
-                        Description
+
+                    <p class="card-title text-secondary" th:text="${panel.email}">
+                        Email
                     </p>
-                    <input th:id="|card_platform_${panel.id}_text|" type="text" class="card-text neg hidden" th:value="${panel.description ?: '상세정보를 입력해주세요!'}">
+                    <th:block th:if="${#strings.isEmpty(panel.description)}">
+                        <p th:id="|card_platform_${panel.id}_label|" class="card-text pos">
+                            Description
+                        </p>
+                    </th:block>
+                    <th:block th:unless="${#strings.isEmpty(panel.description)}">
+                        <p th:id="|card_platform_${panel.id}_label|" th:text="${panel.description}" class="card-text pos">
+                            Description
+                        </p>
+                    </th:block>
+                    <input th:id="|card_platform_${panel.id}_text|" type="text" class="card-text neg hidden" th:value="${panel.description}">
                     <button type="button" th:onclick="|clickWillUpdatePanel_${panel.id}()|" class="btn btn-outline-success pos">수정</button>
                     <button type="button" th:onclick="|clickGetUpdatePanel_${panel.id}()|" class="btn btn-success neg hidden">완료</button>
                     <button type="button" th:onclick="|clickDeletePanel_${panel.id}()|" class="btn btn-outline-danger">삭제</button>


### PR DESCRIPTION
# 개요
![image](https://github.com/iksadNorth/Simpluencer/assets/66674140/1dbc213f-305b-48bf-b40a-26e7e1dbb16b) ![image](https://github.com/iksadNorth/Simpluencer/assets/66674140/ca8a3b89-7402-4dcc-8296-c119693f5434)

인증 직후를 보면 과연 어떤 계정으로 로그인을 했었는지 확인이 되지 않기 때문에 구분하기가 어렵다. 때문에 구분을 쉽게 하기 위해 각 패널에 로그인 당시의 이메일을 아래에 회색 글자로 나타내기로 함.