### PR TITLE
#56 - 일괄_공지_남기기_백엔드_기능_구현

### DIFF
--- a/src/main/java/com/iksad/simpluencer/config/AuthenticationConfig.java
+++ b/src/main/java/com/iksad/simpluencer/config/AuthenticationConfig.java
@@ -31,6 +31,10 @@ public class AuthenticationConfig {
                                 .requestMatchers(antMatcher("/h2/**")).permitAll()
                                 .requestMatchers(antMatcher("/css/**"), antMatcher("/js/**")).permitAll()
 
+                                .requestMatchers(antMatcher(HttpMethod.GET, "/notice/create")).authenticated()
+                                .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/notice/**")).authenticated()
+                                .requestMatchers(antMatcher(HttpMethod.POST, "/api/v1/notice")).authenticated()
+
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/profile/read/**")).permitAll()
 
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/platform/create")).authenticated()

--- a/src/main/java/com/iksad/simpluencer/controller/NoticeApiController.java
+++ b/src/main/java/com/iksad/simpluencer/controller/NoticeApiController.java
@@ -1,0 +1,35 @@
+package com.iksad.simpluencer.controller;
+
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.request.NoticeCreateRequest;
+import com.iksad.simpluencer.model.response.NoticeReadResponse;
+import com.iksad.simpluencer.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.iksad.simpluencer.utils.ResponseEntityUtils.getOkResponse;
+
+@RestController
+@RequestMapping("/api/v1/notice")
+@RequiredArgsConstructor
+public class NoticeApiController {
+    private final NoticeService noticeService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(
+            @AuthenticationPrincipal AgentDto principal,
+            @ModelAttribute NoticeCreateRequest request
+    ) {
+        noticeService.create(principal.id(), request);
+        return getOkResponse();
+    }
+
+    @GetMapping("/{id}")
+    public NoticeReadResponse read(
+            @PathVariable Long id
+    ) {
+        return noticeService.readById(id);
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/controller/NoticeController.java
+++ b/src/main/java/com/iksad/simpluencer/controller/NoticeController.java
@@ -1,24 +1,43 @@
 
 package com.iksad.simpluencer.controller;
 
+import com.iksad.simpluencer.model.AgentDto;
+import com.iksad.simpluencer.model.response.NoticeReadResponse;
+import com.iksad.simpluencer.model.response.PanelReadResponse;
+import com.iksad.simpluencer.service.NoticeService;
+import com.iksad.simpluencer.service.PanelService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/notice")
 @RequiredArgsConstructor
 public class NoticeController {
+    private final NoticeService noticeService;
+    private final PanelService panelService;
 
-    @GetMapping
-    public String notice(@RequestParam(defaultValue = "0") int page, Model model) {
-        model.addAttribute("panels", null);
-        model.addAttribute("notices", null);
-        model.addAttribute("hasNext", null);
-        model.addAttribute("hasPrevious", null);
+    @GetMapping("/create")
+    public String notice(
+            @AuthenticationPrincipal AgentDto principal,
+            @PageableDefault(page = 0, size = 5) Pageable pageable,
+            Model model
+    ) {
+        Slice<NoticeReadResponse> notices = noticeService.read(principal.id(), pageable);
+        List<PanelReadResponse> panels = panelService.getPanelsOf(principal.id());
+
+        model.addAttribute("panels", panels);
+        model.addAttribute("notices", notices);
+        model.addAttribute("hasNext", notices.hasNext());
+        model.addAttribute("hasPrevious", notices.hasPrevious());
         return "notice";
     }
 }

--- a/src/main/java/com/iksad/simpluencer/entity/Agent.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Agent.java
@@ -35,6 +35,9 @@ public class Agent extends BaseEntity {
     @OneToMany(mappedBy = "agent", cascade = {CascadeType.REMOVE, CascadeType.MERGE})
     private Collection<Panel> panels;
 
+    @OneToMany(mappedBy = "writer", cascade = {CascadeType.REMOVE})
+    private Collection<Notice> notices;
+
     public void setRoles(Collection<RoleOfAgent> roles) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/com/iksad/simpluencer/entity/Notice.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Notice.java
@@ -1,0 +1,30 @@
+package com.iksad.simpluencer.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Collection;
+
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "notice", indexes = {
+        @Index(columnList = "writer_id")
+})
+@NoArgsConstructor @Getter @Setter
+public class Notice extends BaseEntity {
+    @CreatedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private Agent writer;
+
+    private String content;
+
+    private String imageUri;
+
+    @OneToMany(mappedBy = "notice", cascade = {CascadeType.REMOVE})
+    private Collection<NotifiedPanel> notifiedPanels;
+}

--- a/src/main/java/com/iksad/simpluencer/entity/NotifiedPanel.java
+++ b/src/main/java/com/iksad/simpluencer/entity/NotifiedPanel.java
@@ -1,0 +1,24 @@
+package com.iksad.simpluencer.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "notified_panel", indexes = {
+        @Index(columnList = "notice_id"),
+        @Index(columnList = "panel_id")
+})
+@NoArgsConstructor @Getter @Setter
+public class NotifiedPanel extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "panel_id")
+    private Panel panel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+}

--- a/src/main/java/com/iksad/simpluencer/exception/ErrorType/NoticeNotFoundType.java
+++ b/src/main/java/com/iksad/simpluencer/exception/ErrorType/NoticeNotFoundType.java
@@ -1,0 +1,24 @@
+package com.iksad.simpluencer.exception.ErrorType;
+
+import com.iksad.simpluencer.exception.SimpluencerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class NoticeNotFoundType extends SimpluencerException {
+    private final Long id;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public String getMessageForClient() {
+        return "해당 공지는 존재하지 않습니다.";
+    }
+
+    public String getMessageForServer() {
+        return String.format("존재하지 않는 Notice로 접근.\nid|%s", this.id);
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/model/WebApiNoticeCreateDto.java
+++ b/src/main/java/com/iksad/simpluencer/model/WebApiNoticeCreateDto.java
@@ -1,0 +1,10 @@
+package com.iksad.simpluencer.model;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record WebApiNoticeCreateDto(
+        String content,
+        String imageUri
+) {
+}

--- a/src/main/java/com/iksad/simpluencer/model/request/NoticeCreateRequest.java
+++ b/src/main/java/com/iksad/simpluencer/model/request/NoticeCreateRequest.java
@@ -1,0 +1,12 @@
+package com.iksad.simpluencer.model.request;
+
+import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
+
+@Builder(toBuilder = true)
+public record NoticeCreateRequest(
+        MultipartFile image,
+        String content,
+        Long[] platforms
+) {
+}

--- a/src/main/java/com/iksad/simpluencer/model/response/NoticeReadResponse.java
+++ b/src/main/java/com/iksad/simpluencer/model/response/NoticeReadResponse.java
@@ -1,0 +1,19 @@
+package com.iksad.simpluencer.model.response;
+
+import com.iksad.simpluencer.entity.Notice;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record NoticeReadResponse(
+        Long id,
+        String content,
+        String image
+) {
+    public static NoticeReadResponse fromEntity(Notice entity) {
+        return NoticeReadResponse.builder()
+                .id(entity.getId())
+                .content(entity.getContent())
+                .image(entity.getImageUri())
+                .build();
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/repository/NoticeRepository.java
+++ b/src/main/java/com/iksad/simpluencer/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package com.iksad.simpluencer.repository;
+
+import com.iksad.simpluencer.entity.Notice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    Slice<Notice> findByWriter_Id(Long agentId, Pageable pageable);
+}

--- a/src/main/java/com/iksad/simpluencer/repository/WebApiRepository.java
+++ b/src/main/java/com/iksad/simpluencer/repository/WebApiRepository.java
@@ -1,0 +1,8 @@
+package com.iksad.simpluencer.repository;
+
+import com.iksad.simpluencer.entity.Panel;
+import com.iksad.simpluencer.model.WebApiNoticeCreateDto;
+
+public interface WebApiRepository {
+    void createNotice(Panel panel, WebApiNoticeCreateDto dto);
+}

--- a/src/main/java/com/iksad/simpluencer/repository/WebApiRepositoryImpl.java
+++ b/src/main/java/com/iksad/simpluencer/repository/WebApiRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.iksad.simpluencer.repository;
+
+import com.iksad.simpluencer.entity.Panel;
+import com.iksad.simpluencer.model.WebApiNoticeCreateDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebApiRepositoryImpl implements WebApiRepository {
+    @Override
+    public void createNotice(Panel panel, WebApiNoticeCreateDto dto) {
+
+    }
+}

--- a/src/main/java/com/iksad/simpluencer/service/NoticeService.java
+++ b/src/main/java/com/iksad/simpluencer/service/NoticeService.java
@@ -1,0 +1,14 @@
+package com.iksad.simpluencer.service;
+
+import com.iksad.simpluencer.model.request.NoticeCreateRequest;
+import com.iksad.simpluencer.model.response.NoticeReadResponse;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
+
+public interface NoticeService {
+    Slice<NoticeReadResponse> read(Long agentId, Pageable pageable);
+
+    void create(Long agentId, NoticeCreateRequest request);
+
+    NoticeReadResponse readById(Long id);
+}

--- a/src/main/java/com/iksad/simpluencer/service/NoticeServiceImpl.java
+++ b/src/main/java/com/iksad/simpluencer/service/NoticeServiceImpl.java
@@ -1,0 +1,74 @@
+package com.iksad.simpluencer.service;
+
+import com.iksad.simpluencer.entity.Notice;
+import com.iksad.simpluencer.entity.Panel;
+import com.iksad.simpluencer.exception.ErrorType.NoticeNotFoundType;
+import com.iksad.simpluencer.model.WebApiNoticeCreateDto;
+import com.iksad.simpluencer.model.request.NoticeCreateRequest;
+import com.iksad.simpluencer.model.response.NoticeReadResponse;
+import com.iksad.simpluencer.repository.NoticeRepository;
+import com.iksad.simpluencer.repository.PanelRepository;
+import com.iksad.simpluencer.repository.WebApiRepository;
+import com.iksad.simpluencer.utils.VarInspectUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NoticeServiceImpl implements NoticeService {
+    private final NoticeRepository noticeRepository;
+    private final PanelRepository panelRepository;
+    private final ImageService imageService;
+    private final WebApiRepository webApiRepository;
+
+    @Override
+    public void create(Long agentId, NoticeCreateRequest request) {
+        Notice entity = new Notice();
+
+        // 이미지 업로드하고
+        MultipartFile image = request.image();
+        String imageUri = null;
+        if (!image.isEmpty()) {
+            imageUri = imageService.save(image);
+            entity.setImageUri(imageUri);
+        }
+
+        // 각 플랫폼에 업로드하기.
+        WebApiNoticeCreateDto noticeCreateDto = WebApiNoticeCreateDto.builder()
+                .content(request.content())
+                .imageUri(imageUri)
+                .build();
+
+        Long[] panelIds = request.platforms();
+        List<Panel> panelsSelected = panelRepository.findAllById(List.of(panelIds));
+        panelsSelected.forEach(panel -> webApiRepository.createNotice(panel, noticeCreateDto));
+
+        // 공지 테이블에 저장.
+        String content = request.content();
+        if (!VarInspectUtils.isBlank(content)) {
+            entity.setContent(content);
+        }
+
+        noticeRepository.save(entity);
+    }
+
+    @Override
+    public NoticeReadResponse readById(Long id) {
+        return noticeRepository.findById(id)
+                .map(NoticeReadResponse::fromEntity)
+                .orElseThrow(() -> new NoticeNotFoundType(id));
+    }
+
+    @Override
+    public Slice<NoticeReadResponse> read(Long agentId, Pageable pageable) {
+        return noticeRepository.findByWriter_Id(agentId, pageable)
+                .map(NoticeReadResponse::fromEntity);
+    }
+}

--- a/src/main/resources/templates/component/notice.html
+++ b/src/main/resources/templates/component/notice.html
@@ -36,6 +36,11 @@
             const input = document.getElementById('board-text');
             input.value = content;
         }
+        function resetNoticeContent() {
+            const input = document.getElementById('board-text');
+            input.value = "";
+            localStorage.removeItem('notice-content');
+        }
 
         const textarea = document.querySelector('#board-text');
         textarea.addEventListener('input', function(e) {
@@ -77,12 +82,11 @@
         }
     </style>
 
-    <div><br></div>
     <th:block th:each="panel : ${panels}">
-        <div th:id="platform-btn-${panel?.id}" th:panelid="${panel?.id}"
+        <div th:id="|platform-btn-${panel.id}|" th:panelid="${panel.id}"
              class="platform selected text-center"
-             th:onclick="|toggleHandler('platform-btn-${panel?.id}|')"
-             th:text="${panel?.description}"
+             th:onclick="|toggleHandler('platform-btn-${panel.id}')|"
+             th:text="${panel.description}"
         >
             Description
         </div>
@@ -98,8 +102,8 @@
         }
 
         function resetPlatforms() {
-            const elePlatform = document.querySelectorAll('#selector-platform .platform');
-            elePlatform.map((El) => {
+            const elePlatform = document.querySelectorAll('#selector-platform .platform.selected');
+            elePlatform.forEach((El) => {
                 El.classList.remove('selected');
             });
         }
@@ -132,10 +136,20 @@
         const content = getNoticeContent();
         const platforms = getPlatforms();
 
-        post(`/api/v1/notice`).then((res) => {
-            setNoticeContent("");
+        const formdata = new FormData();
+        formdata.append('image', image[0]);
+        formdata.append('content', content);
+        formdata.append('platforms', platforms);
+
+        post(`/api/v1/notice`, {
+            body: formdata,
+            noContentType: true,
+        }).then((res) => {
+            resetNoticeContent();
             setImgSrc("#");
             resetPlatforms();
+
+            reloadPage();
         }).catch(doWhenErr);
     }
     </script>
@@ -232,15 +246,15 @@
         <th:block th:each="notice : ${notices}">
         <tr>
             <td>
-                <img class="notice-img" th:src="${notice?.image}">
+                <img class="notice-img" th:src="@{/img/{image}(image=${notice.image})}">
             </td>
             <td>
-                <div class="notice-desc" th:text="${notice?.content}">
+                <div class="notice-desc" th:text="${notice.content}">
                     desc
                 </div>
             </td>
             <td>
-                <div class="button" th:onclick="|takeNoticeHistory(${notice?.id})|">
+                <div class="button" th:onclick="|takeNoticeHistory(${notice.id})|">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
                         <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
                         <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
@@ -266,7 +280,7 @@
     function takeNoticeHistory(noticeId) {
         get(`/api/v1/notice/${noticeId}`).then((res) => {
             setNoticeContent(res.content);
-            setImgSrc(res.image);
+            setImgSrc(`/img/${res.image}`);
         }).catch(doWhenErr);
     }
 
@@ -279,8 +293,10 @@
         const el_next = document.querySelector('#btn-next-page');
         const el_previous = document.querySelector('#btn-previous-page');
 
-        el_next.disable = ![[${hasNext}]];
-        el_previous.disable = ![[${hasPrevious}]];
+        const flagHasNext = [[${hasNext}]];
+        const flagHasPrevious = [[${hasPrevious}]];
+        el_next.disable = !flagHasNext;
+        el_previous.disable = !flagHasPrevious;
     }
     setBtnDisable();
 

--- a/src/test/java/com/iksad/simpluencer/controller/NoticeApiControllerTest.java
+++ b/src/test/java/com/iksad/simpluencer/controller/NoticeApiControllerTest.java
@@ -1,0 +1,76 @@
+package com.iksad.simpluencer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iksad.simpluencer.model.request.NoticeCreateRequest;
+import com.iksad.simpluencer.service.NoticeService;
+import com.iksad.simpluencer.tools.MockBeansForController;
+import com.iksad.simpluencer.tools.MockMvcTools;
+import com.iksad.simpluencer.tools.MockSecurityContextFactory.WithMockPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static com.iksad.simpluencer.tools.ImageTools.loadImage;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser
+@WebMvcTest(NoticeApiController.class)
+@MockBeansForController
+@MockBean(NoticeService.class)
+@DisplayName("[NoticeApiController]")
+class NoticeApiControllerTest {
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper objectMapper;
+    @InjectMocks private PanelApiController panelApiController;
+
+    private MockMvcTools tools;
+
+    @BeforeEach
+    public void setup() {
+        if(this.tools == null)
+            this.tools = new MockMvcTools(objectMapper, mvc);
+    }
+
+    @WithMockPrincipal
+    @Test @DisplayName("[create][정상]")
+    void create() throws Exception {
+        // Given
+        byte[] image = loadImage("https://cdn.pixabay.com/photo/2023/05/11/13/11/man-7986401_1280.jpg");
+        String originalName = "mock original name.jpg";
+        MockMultipartFile multipartFile = new MockMultipartFile("mock name", originalName, null, image);
+
+        NoticeCreateRequest request = NoticeCreateRequest.builder()
+                .content("mock content")
+                .platforms(new Long[]{2L, 1L, 4L, 3L, 5L})
+                .image(multipartFile)
+                .build();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("content", request.content());
+        for (Long location : request.platforms()) {
+            params.add("platforms", String.valueOf(location));
+        }
+
+        // When & Then
+        tools.multipartForm("/api/v1/notice", (MockMultipartFile) request.image(), params)
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test @DisplayName("[read][정상]")
+    void read() throws Exception {
+        tools.getApi("/api/v1/notice/1")
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/iksad/simpluencer/controller/NoticeControllerTest.java
+++ b/src/test/java/com/iksad/simpluencer/controller/NoticeControllerTest.java
@@ -1,0 +1,99 @@
+package com.iksad.simpluencer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iksad.simpluencer.model.response.NoticeReadResponse;
+import com.iksad.simpluencer.model.response.PanelReadResponse;
+import com.iksad.simpluencer.service.NoticeService;
+import com.iksad.simpluencer.service.PanelService;
+import com.iksad.simpluencer.tools.MockBeansForController;
+import com.iksad.simpluencer.tools.MockMvcTools;
+import com.iksad.simpluencer.tools.MockSecurityContextFactory.WithMockPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WithMockUser
+@WebMvcTest(NoticeController.class)
+@MockBeansForController
+@DisplayName("[NoticeController]")
+class NoticeControllerTest {
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper objectMapper;
+    @InjectMocks private PanelApiController panelApiController;
+    @MockBean NoticeService noticeService;
+    @MockBean PanelService panelService;
+
+    private MockMvcTools tools;
+
+    @BeforeEach
+    public void setup() {
+        if(this.tools == null)
+            this.tools = new MockMvcTools(objectMapper, mvc);
+    }
+
+    @WithMockPrincipal
+    @Test @DisplayName("[notice][정상]")
+    void notice() throws Exception {
+        // Given
+        NoticeReadResponse noticeReadResponse = NoticeReadResponse.builder()
+                .id(1L)
+                .image("mock_image.jpg")
+                .content("mock content")
+                .build();
+        PageRequest pageRequest = PageRequest.of(3, 2);
+        SliceImpl<NoticeReadResponse> noticeReadResponses = new SliceImpl<NoticeReadResponse>(
+                List.of(noticeReadResponse,noticeReadResponse), pageRequest, true
+        );
+
+        given(noticeService.read(any(), any())).willReturn(noticeReadResponses);
+
+        PanelReadResponse panelReadResponse = PanelReadResponse.builder()
+                .id(1L)
+                .frontName("mock name")
+                .icon("mock_icon")
+                .description("mock desc")
+                .build();
+        given(panelService.getPanelsOf(any())).willReturn(List.of(panelReadResponse));
+
+        // When & Then
+        String platformBtnId = String.format("id=\"platform-btn-%s\"", panelReadResponse.id());
+        String panelId = String.format("panelid=\"%s\"", panelReadResponse.id());
+        String panelOnclick = String.format("onclick=\"toggleHandler(&#39;platform-btn-%s&#39;)\"", panelReadResponse.id());
+        String description = String.format("%s", panelReadResponse.description());
+
+        String content = String.format("%s", noticeReadResponse.content());
+        String takeNiceHistory = String.format("onclick=\"takeNoticeHistory(%s)\"", noticeReadResponse.id());
+
+        String hasNext = String.format("const flagHasNext = %s;", noticeReadResponses.hasNext());
+
+        tools.getView("/notice/create")
+                .andExpect(view().name("notice"))
+                .andExpect(content().string(containsString(platformBtnId)))
+                .andExpect(content().string(containsString(panelId)))
+                .andExpect(content().string(containsString(panelOnclick)))
+                .andExpect(content().string(containsString(description)))
+
+                .andExpect(content().string(containsString(content)))
+                .andExpect(content().string(containsString(takeNiceHistory)))
+
+                .andExpect(content().string(containsString(hasNext)))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/iksad/simpluencer/tools/MockMvcTools.java
+++ b/src/test/java/com/iksad/simpluencer/tools/MockMvcTools.java
@@ -33,6 +33,13 @@ public class MockMvcTools {
         );
     }
 
+    public ResultActions getApi(String url) throws Exception {
+        return mvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .with(csrf())
+        );
+    }
+
     public <T> ResultActions patchJson(String url, T request) throws Exception {
         return mvc.perform(
                 patch(url)


### PR DESCRIPTION
# 개요
실제로 공지를 남기면 DB에 저장되고 API를 이용해 공지를 써주는 기능을 추가.

# 미흡한 점
아직 API를 이용하는 부분은 구현이 되지 않았으나 그 외의 부분들은 구현
- 공지를 DB에 저장.
- 페이징 기능 구현
- 지난 공지 가져오기 기능 구현
- 플랫폼 선택 기능 구현.