### PR TITLE
#60 - multipartfile을_null값으로_넘길_때_생기는_버그_수정

### DIFF
--- a/src/main/java/com/iksad/simpluencer/service/NoticeServiceImpl.java
+++ b/src/main/java/com/iksad/simpluencer/service/NoticeServiceImpl.java
@@ -30,12 +30,14 @@ public class NoticeServiceImpl implements NoticeService {
 
     @Override
     public void create(Long agentId, NoticeCreateRequest request) {
+        boolean doHaveNotRequiredAttr = true;
         Notice entity = new Notice();
 
         // 이미지 업로드하고
         MultipartFile image = request.image();
         String imageUri = null;
-        if (!image.isEmpty()) {
+        if (image != null && !image.isEmpty()) {
+            doHaveNotRequiredAttr = false;
             imageUri = imageService.save(image);
             entity.setImageUri(imageUri);
         }
@@ -53,10 +55,13 @@ public class NoticeServiceImpl implements NoticeService {
         // 공지 테이블에 저장.
         String content = request.content();
         if (!VarInspectUtils.isBlank(content)) {
+            doHaveNotRequiredAttr = false;
             entity.setContent(content);
         }
 
-        noticeRepository.save(entity);
+        if(!doHaveNotRequiredAttr) {
+            noticeRepository.save(entity);
+        }
     }
 
     @Override

--- a/src/main/resources/templates/component/notice.html
+++ b/src/main/resources/templates/component/notice.html
@@ -137,9 +137,15 @@
         const platforms = getPlatforms();
 
         const formdata = new FormData();
-        formdata.append('image', image[0]);
-        formdata.append('content', content);
-        formdata.append('platforms', platforms);
+        if(image[0]) {
+            formdata.append('image', image[0]);
+        }
+        if(content) {
+            formdata.append('content', content);
+        }
+        if(platforms) {
+            formdata.append('platforms', platforms);
+        }
 
         post(`/api/v1/notice`, {
             body: formdata,

--- a/src/main/resources/templates/component/profile.html
+++ b/src/main/resources/templates/component/profile.html
@@ -168,10 +168,18 @@
             });
 
             const formdata = new FormData();
-            formdata.append("nickname", nickname);
-            formdata.append("introduction", introduction);
-            formdata.append("image", file);
-            formdata.append("locations", locations);
+            if(nickname) {
+                formdata.append("nickname", nickname);
+            }
+            if(introduction) {
+                formdata.append("introduction", introduction);
+            }
+            if(file) {
+                formdata.append("image", file);
+            }
+            if(locations) {
+                formdata.append("locations", locations);
+            }
 
             post(`/api/v1/profile`, {
                 noContentType: true,


### PR DESCRIPTION
# 개요
프로필 수정이나 공지 작성 시, 이미지를 서버로 전달하게 되는데 프론트에서 formData에 이미지를 넣을 때, 이미값이 null일 때, 아무런 인자를 넣지 않는 것이 아니라 null이라는 문자열을 전달함을 확인했다. 따라서 프론트에서 만약 null값임을 파악하면 아예 formdata에 추가하지 않게 설정함. 동시에 백엔드단에서도 아무런 값이 넘어오지 않으면 공지 작성 api를 호출해도 공지를 생성하지 않게 조치를 취함.