### PR TITLE
#68 - OAuthRequestUriUtilsTest_코드_내용_변경

### DIFF
--- a/src/test/java/com/iksad/simpluencer/utils/OAuthRequestUriUtilsTest.java
+++ b/src/test/java/com/iksad/simpluencer/utils/OAuthRequestUriUtilsTest.java
@@ -65,9 +65,5 @@ class OAuthRequestUriUtilsTest {
         assertThat(uri).contains(
                 "response_type=code"
         );
-        assertThat(uri).contains(
-                "access_type=offline"
-        );
-
     }
 }


### PR DESCRIPTION
# 기존 문제점
범용 적인 OAuth2 인증 링크를 만들기 위해 Googel에서만 요구하던 access_type-offline 부분을 제거함. 기존 코드에서는 제거했지만 테스트코드에서는 이를 반영하지 못해서 이를 반영함.