### PR TITLE
#78 - 디지털_명함_페이지에서_패널_클릭_시_링크로_이동케하기

### DIFF
--- a/src/main/java/com/iksad/simpluencer/entity/Panel.java
+++ b/src/main/java/com/iksad/simpluencer/entity/Panel.java
@@ -28,4 +28,6 @@ public class Panel extends BaseEntity {
     private String account;
 
     private int location;
+
+    private String link;
 }

--- a/src/main/java/com/iksad/simpluencer/model/request/PanelUpdateRequest.java
+++ b/src/main/java/com/iksad/simpluencer/model/request/PanelUpdateRequest.java
@@ -8,12 +8,15 @@ import static com.iksad.simpluencer.utils.VarInspectUtils.isBlank;
 @Builder(toBuilder = true)
 public record PanelUpdateRequest(
         String description,
-        int location
+        int location,
+        String link
 ) {
     public void overwrite(Panel entity) {
         if(!isBlank(this.description))
             entity.setDescription(this.description);
         if(this.location != 0)
             entity.setLocation(this.location);
+        if(!isBlank(this.link))
+            entity.setLink(this.link);
     }
 }

--- a/src/main/java/com/iksad/simpluencer/model/response/PanelReadResponse.java
+++ b/src/main/java/com/iksad/simpluencer/model/response/PanelReadResponse.java
@@ -10,7 +10,8 @@ public record PanelReadResponse(
         String frontName,
         String icon,
         String description,
-        String email
+        String email,
+        String link
 ) {
     public static PanelReadResponse of(Panel entity) {
         String provider = entity.getProvider();
@@ -21,6 +22,7 @@ public record PanelReadResponse(
                 .icon(type.getIcon())
                 .description(entity.getDescription())
                 .email(entity.getAccount())
+                .link(entity.getLink())
                 .build();
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -152,3 +152,7 @@ textarea::-webkit-scrollbar-thumb:hover {
 
     background-color: #40a168;
 }
+
+.clickable {
+    cursor: pointer;
+}

--- a/src/main/resources/templates/component/platform.html
+++ b/src/main/resources/templates/component/platform.html
@@ -42,9 +42,20 @@
                     <p class="card-title text-secondary" th:text="${panel.email}">
                         Email
                     </p>
+                    <th:block th:if="${#strings.isEmpty(panel.link)}">
+                        <p th:id="|card_platform_${panel.id}_link|" class="card-text pos text-secondary">
+                            링크 입력란
+                        </p>
+                    </th:block>
+                    <th:block th:unless="${#strings.isEmpty(panel.link)}">
+                        <p th:id="|card_platform_${panel.id}_link|" th:text="${panel.link}" class="card-text pos text-secondary">
+                            Link
+                        </p>
+                    </th:block>
+                    <input th:id="|card_platform_${panel.id}_text_link|" type="text" class="card-text neg hidden" th:value="${panel.link}">
                     <th:block th:if="${#strings.isEmpty(panel.description)}">
                         <p th:id="|card_platform_${panel.id}_label|" class="card-text pos">
-                            Description
+                            상세 설명 기입란
                         </p>
                     </th:block>
                     <th:block th:unless="${#strings.isEmpty(panel.description)}">
@@ -93,9 +104,14 @@
             const labelElement = document.getElementById([[|card_platform_${panel.id}_label|]]);
             labelElement.innerText = textElement.value;
 
+            const textLinkElement = document.getElementById([[|card_platform_${panel.id}_text_link|]]);
+            const linkElement = document.getElementById([[|card_platform_${panel.id}_link|]]);
+            linkElement.innerText = textLinkElement.value;
+
             patch(`/api/v1/panel/[[${panel.id}]]`, {
                 body: JSON.stringify({
                     description: labelElement.innerText,
+                    link: linkElement.innerText,
                 }),
             }).then(reloadPage).catch(doWhenErr);
         }

--- a/src/main/resources/templates/component/profile.html
+++ b/src/main/resources/templates/component/profile.html
@@ -192,7 +192,7 @@
 <div th:fragment="panel" class="block" th:id="|panel_${panel.id}|">
     <div class="card tada">
         <div class="row g-0">
-            <div class="col-md-4">
+            <div class="col-md-4 clickable" th:data-link="${panel.link ?: '#'}" onclick="navigateTo(this.getAttribute('data-link'))">
                 <svg
                         class="bd-placeholder-img"
                         width="100%" height="150"

--- a/src/test/java/com/iksad/simpluencer/controller/ProfileControllerTest.java
+++ b/src/test/java/com/iksad/simpluencer/controller/ProfileControllerTest.java
@@ -1,0 +1,87 @@
+package com.iksad.simpluencer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iksad.simpluencer.model.response.PanelReadResponse;
+import com.iksad.simpluencer.model.response.ProfileResponse;
+import com.iksad.simpluencer.service.AgentService;
+import com.iksad.simpluencer.tools.MockBeansForController;
+import com.iksad.simpluencer.tools.MockMvcTools;
+import com.iksad.simpluencer.tools.MockSecurityContextFactory.WithMockPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@WithMockPrincipal
+@WebMvcTest(ProfileController.class)
+@MockBeansForController
+@DisplayName("[ProfileController]")
+class ProfileControllerTest {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired private ObjectMapper objectMapper;
+    @InjectMocks
+    private ProfileController profileController;
+    @MockBean
+    private AgentService agentService;
+
+    private MockMvcTools tools;
+
+    @BeforeEach
+    public void setup() {
+        if(this.tools == null)
+            this.tools = new MockMvcTools(objectMapper, mvc);
+    }
+
+    @Test @DisplayName("[read][정상]Panel이 주어졌을 때, 특정 문구 포함 여부.")
+    void readWhenPanelGiven() throws Exception {
+        // Given
+        PanelReadResponse panelReadResponse = PanelReadResponse.builder()
+                .id(1L)
+                .link("mock link")
+                .build();
+        ProfileResponse profileResponse = ProfileResponse.builder()
+                .panels(List.of(panelReadResponse))
+                .build();
+        given(agentService.readProfileById(any())).willReturn(profileResponse);
+
+        // When & Then
+        String onclickLink = String.format("<div class=\"col-md-4 clickable\" data-link=\"%s\" onclick=\"navigateTo(this.getAttribute('data-link'))\">", panelReadResponse.link());
+
+        tools.getView("/profile/read/1")
+                .andExpect(content().string(containsString(onclickLink)))
+                .andDo(print());
+    }
+
+    @Test @DisplayName("[read][정상]Panel의 link값이 null값으로 주어졌을 때, 링크는 #으로 제공.")
+    void readWhenPanelGivenWithoutLink() throws Exception {
+        // Given
+        PanelReadResponse panelReadResponse = PanelReadResponse.builder()
+                .id(1L)
+                .link(null)
+                .build();
+        ProfileResponse profileResponse = ProfileResponse.builder()
+                .panels(List.of(panelReadResponse))
+                .build();
+        given(agentService.readProfileById(any())).willReturn(profileResponse);
+
+        // When & Then
+        String onclickLink = "<div class=\"col-md-4 clickable\" data-link=\"#\" onclick=\"navigateTo(this.getAttribute('data-link'))\">";
+
+        tools.getView("/profile/read/1")
+                .andExpect(content().string(containsString(onclickLink)))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
# 개요
디지털 명함 페이지에서 패널을 클릭해서 해당 링크로 넘어가지 않았던 것을 수정함.